### PR TITLE
Fix oneof equals

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/templates/equal/msg.go
+++ b/templates/equal/msg.go
@@ -28,11 +28,22 @@ func (m {{ (msgTyp .).Pointer }}) Equal(that interface{}) bool {
 
 		{{ range .OneOfs }}
 			switch m.{{ name . }}.(type) {
+				{{ $oneOfInterface := name .}}
 				{{ range .Fields }}
 					case {{ oneof . }}:
+						if _, ok := target.{{ $oneOfInterface }}.({{ oneof . }}); !ok {
+							return false
+						}
+
 						{{ render . }}
 				{{ end }}
+					default:
+						// m is nil but target is not nil
+						if m.{{ name . }} != target.{{ name . }} {
+							return false
+						}
 			}
+
 		{{ end }}
 
 

--- a/tests/api/hello.pb.equal.go
+++ b/tests/api/hello.pb.equal.go
@@ -262,6 +262,9 @@ func (m *Nested) Equal(that interface{}) bool {
 	switch m.TestOneOf.(type) {
 
 	case *Nested_EmptyOneOf:
+		if _, ok := target.TestOneOf.(*Nested_EmptyOneOf); !ok {
+			return false
+		}
 
 		if h, ok := interface{}(m.GetEmptyOneOf()).(equality.Equalizer); ok {
 			if !h.Equal(target.GetEmptyOneOf()) {
@@ -274,6 +277,9 @@ func (m *Nested) Equal(that interface{}) bool {
 		}
 
 	case *Nested_NestedOneOf:
+		if _, ok := target.TestOneOf.(*Nested_NestedOneOf); !ok {
+			return false
+		}
 
 		if h, ok := interface{}(m.GetNestedOneOf()).(equality.Equalizer); ok {
 			if !h.Equal(target.GetNestedOneOf()) {
@@ -285,6 +291,11 @@ func (m *Nested) Equal(that interface{}) bool {
 			}
 		}
 
+	default:
+		// m is nil but target is not nil
+		if m.TestOneOf != target.TestOneOf {
+			return false
+		}
 	}
 
 	return true

--- a/tests/equal_test.go
+++ b/tests/equal_test.go
@@ -87,6 +87,53 @@ var _ = Describe("equal", func() {
 			&api.Nested{}, api.Nested{}, true,
 		),
 		Entry(
+			"source non-nil oneOf, target nil",
+			&api.Nested{
+				TestOneOf: &api.Nested_NestedOneOf{
+					NestedOneOf: &api.NestedEmpty{
+						Nested: &api.Nested{
+							Simple: &api.Simple{Str: "hello"},
+						},
+					},
+				},
+			},
+			&api.Nested{}, false,
+		),
+		Entry(
+			"source nil oneOf, target non-nil",
+			&api.Nested{},
+			&api.Nested{
+				TestOneOf: &api.Nested_NestedOneOf{
+					NestedOneOf: &api.NestedEmpty{
+						Nested: &api.Nested{
+							Simple: &api.Simple{Str: "hello"},
+						},
+					},
+				},
+			}, false,
+		),
+		Entry(
+			"source & target non-nil equal oneOfs",
+			&api.Nested{
+				TestOneOf: &api.Nested_NestedOneOf{
+					NestedOneOf: &api.NestedEmpty{
+						Nested: &api.Nested{
+							Simple: &api.Simple{Str: "hello"},
+						},
+					},
+				},
+			},
+			&api.Nested{
+				TestOneOf: &api.Nested_NestedOneOf{
+					NestedOneOf: &api.NestedEmpty{
+						Nested: &api.Nested{
+							Simple: &api.Simple{Str: "hello"},
+						},
+					},
+				},
+			}, true,
+		),
+		Entry(
 			"foreign struct (equal)",
 			&api.Nested{
 				Details: &structpb.Struct{},


### PR DESCRIPTION
Fixes a bug where Equality was erroneously evaluating to true for `oneOf` cases where one was nil and the other was not.

Example where we encountered this in waf settings in Gloo:

```
l1 := &v1.Listener{
		Name: "listener-::-8080",
		ListenerType: &v1.Listener_HttpListener{
			HttpListener: &v1.HttpListener{
				Options: &v1.HttpListenerOptions{
					Waf: &waf.Settings{
						CoreRuleSet: &waf.CoreRuleSet{},
					},
				},
			},
		},
	}
	l2 := &v1.Listener{
		Name: "listener-::-8080",
		ListenerType: &v1.Listener_HttpListener{
			HttpListener: &v1.HttpListener{
				Options: &v1.HttpListenerOptions{
					Waf: &waf.Settings{
						CoreRuleSet: &waf.CoreRuleSet{
							CustomSettingsType: &waf.CoreRuleSet_CustomSettingsString{
								CustomSettingsString: "",
							},
						},
					},
				},
			},
		},
	}

	result1 := l1.Equal(l2) // returns true
	result2 := l2.Equal(l1) // returns false
```

This was due to the generated `switch` statement not accounting for the first value being nil, with the second value being not nil.

Another corner case that was failing is where the first element is set to a zero-value in go (blank string, false etc), but the second element has no value explicitly set. These should not be equal, but they were resolving to true.

This PR fixes these two cases, also adds tests to confirm.