### PR TITLE
add use for strconv import in unique hasher

### DIFF
--- a/templates/uniquehash/file.go
+++ b/templates/uniquehash/file.go
@@ -28,6 +28,7 @@ var (
 	_ = binary.LittleEndian
 	_ = new(hash.Hash64)
 	_ = fnv.New64
+	_ = strconv.Itoa
 	_ = hashstructure.Hash
 	_ = new(safe_hasher.SafeHasher)
 


### PR DESCRIPTION
The `strconv` import in the `templates/uniquehash` package could go unused, depending on the type of the object to be hashed. This PR adds a no-op usage for it so that the compiler does not throw errors.